### PR TITLE
Rename method operator improvements

### DIFF
--- a/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
+++ b/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
@@ -57,7 +57,8 @@ RenameMethodMutationOperator >> canRefactor: aNode [
 		               permutation: #(  ).
 
 	refactoring prepareForExecution.
-	failing := refactoring failedApplicabilityPreconditions.
+	failing := refactoring failedApplicabilityPreconditions asOrderedCollection.
+	failing addAll: refactoring failedBreakingChangePreconditions.
 	^ failing isEmpty
 ]
 

--- a/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
+++ b/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
@@ -18,6 +18,14 @@ RenameMethodMutationOperator >> affectedNodesFor: aParseTree [
 ]
 
 { #category : 'instance creation' }
+RenameMethodMutationOperator >> appliesToNode: aNode [
+
+	(aNode isMessage or: [ aNode isMethod ]) ifFalse: [ ^ false ].
+
+	^ super appliesToNode: aNode
+]
+
+{ #category : 'instance creation' }
 RenameMethodMutationOperator >> applyMutation: aMutation [
 
 	| refactoring failing |

--- a/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
+++ b/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
@@ -81,7 +81,6 @@ RenameMethodMutationOperator >> mutationsFor: aCompiledMethod with: aParseTree [
 		 aCompiledMethod hasPragmaNamed: #ignoreForCoverage ]) ifTrue: [
 		^ #(  ) ].
 
-1halt.
 	affectedNodes := self affectedNodesFor: aParseTree.
 	^ affectedNodes collectWithIndex: [ :affectedNode :index |
 		  RefactoringMutation

--- a/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
+++ b/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
@@ -49,6 +49,7 @@ RenameMethodMutationOperator >> applyMutation: aMutation [
 RenameMethodMutationOperator >> canRefactor: aNode [
 
 	| refactoring failing |
+	({ #size . #new . #initialize } includes: aNode selector) ifTrue: [ ^ false ].
 	refactoring := ReRenameMethodRefactoring
 		               renameMethod: aNode selector
 		               in: aNode methodNode methodClass name

--- a/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
+++ b/src/RefactoringTestExperiments/RenameMethodMutationOperator.class.st
@@ -28,18 +28,18 @@ RenameMethodMutationOperator >> appliesToNode: aNode [
 { #category : 'instance creation' }
 RenameMethodMutationOperator >> applyMutation: aMutation [
 
-	| refactoring failing |
-	refactoring := ReRenameMethodRefactoring
-		               renameMethod: (aMutation originalMethod sourceCode
+	| refactoring failing parsedExpression |
+	parsedExpression := RBParser parseExpression: (aMutation originalMethod sourceCode
 				                copyFrom: aMutation data first
-				                to: aMutation data last)
+				                to: aMutation data last).
+	refactoring := ReRenameMethodRefactoring
+		               renameMethod: parsedExpression selector
 		               in: aMutation originalMethod methodClass name
-		               to: #foo
+		               to: 'new' , parsedExpression selector
 		               permutation: #(  ).
 
 	refactoring prepareForExecution.
-	failing := refactoring applicabilityPreconditions reject: [ :cond |
-		           cond check ].
+	failing := refactoring failedApplicabilityPreconditions.
 	failing ifNotEmpty: [ RBRefactoringError signal ].
 	refactoring privateTransform.
 	refactoring performChanges
@@ -50,14 +50,13 @@ RenameMethodMutationOperator >> canRefactor: aNode [
 
 	| refactoring failing |
 	refactoring := ReRenameMethodRefactoring
-		               renameMethod: aNode sourceCode
+		               renameMethod: aNode selector
 		               in: aNode methodNode methodClass name
-		               to: #foo
+		               to: 'new' , aNode selector
 		               permutation: #(  ).
 
 	refactoring prepareForExecution.
-	failing := refactoring applicabilityPreconditions reject: [ :cond |
-		           cond check ].
+	failing := refactoring failedApplicabilityPreconditions.
 	^ failing isEmpty
 ]
 


### PR DESCRIPTION
- only apply rename on method nodes and message sends
- skip rename of selectors with 10k+ usages (freezes the image)
- new name is old name with `new` prefix

With these changes I got:
23 alive mutants and 64 terminated (0 killed)

TODO:
- a lot of terminated mutants are because of permutations, need to create a way to send permutations in, or put default permutations in refactoring if they are not supplied
- have yet to analyze other terminations